### PR TITLE
Don't bind NaN

### DIFF
--- a/bin/http-to-https
+++ b/bin/http-to-https
@@ -21,7 +21,7 @@ const server = http.createServer( (req, res) => {
 let port = 8000
 
 if(fs.existsSync(portFilePath)){
-  port = parseInt( fs.readFileSync(portFilePath) )
+  port = parseInt( fs.readFileSync(portFilePath) ) || port
 }
 
 console.log('listening on port:', port)


### PR DESCRIPTION
# Issues

* #1

## Root Cause

It appears during install `configure` hook gets called but with no port set. So a blank port config file is created resulting in a NaN port value